### PR TITLE
support group chat while run in privacy mode

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -137,7 +137,7 @@ class ChatGPT3TelegramBot:
         application.add_handler(MessageHandler(filters.TEXT & (~filters.COMMAND), self.prompt))
         application.add_handler(
             MessageHandler(
-                (filters.TEXT | filters.REPLAY) & (~filters.COMMAND), self.prompt
+                (filters.TEXT | filters.REPLY) & (~filters.COMMAND), self.prompt
             )
         )
 

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -135,6 +135,11 @@ class ChatGPT3TelegramBot:
         application.add_handler(CommandHandler('reset', self.reset))
         application.add_handler(CommandHandler('help', self.help))
         application.add_handler(MessageHandler(filters.TEXT & (~filters.COMMAND), self.prompt))
+        application.add_handler(
+            MessageHandler(
+                (filters.TEXT | filters.REPLAY) & (~filters.COMMAND), self.prompt
+            )
+        )
 
         application.add_error_handler(self.error_handler)
 


### PR DESCRIPTION
background:

By default, all bots added to groups run in  [Privacy Mode](https://core.telegram.org/bots/features#privacy-mode)

only see relevant messages and commands, see above link for detail.

we get this :

-  Replies to any messages implicitly or explicitly meant for this bot.

Design:

- use filters.REPLY
- let bot run in privacy mode (default)
- add a `/chat` command, send a message to group

how to use:
- user use /chat command or /chat xxxx some new text in chat
- bot will send a message in chat
- user reply to bot's  message