### PR TITLE
add option to omit sending msg history with each openei completion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ ALLOWED_TELEGRAM_USER_IDS="USER_ID_1,USER_ID_2"
 
 # Whether to show OpenAI token usage information after each response
 SHOW_USAGE=false
+
+# Whether to save message history for sending back to openai with each completion
+OMIT_MSG_HISTORY=false

--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ def main():
         'show_usage': os.environ.get('SHOW_USAGE', 'false').lower() == 'true',
         'proxy': os.environ.get('PROXY', None),
         'omit_msg_history': os.environ.get('OMIT_MSG_HISTORY', 'false').lower() == 'true',
+        'max_msg_history': int(os.environ.get('MAX_MSG_HISTORY', 10)),
 
         # 'gpt-3.5-turbo' or 'gpt-3.5-turbo-0301'
         'model': 'gpt-3.5-turbo',

--- a/main.py
+++ b/main.py
@@ -29,6 +29,7 @@ def main():
         'api_key': os.environ['OPENAI_API_KEY'],
         'show_usage': os.environ.get('SHOW_USAGE', 'false').lower() == 'true',
         'proxy': os.environ.get('PROXY', None),
+        'omit_msg_history': os.environ.get('OMIT_MSG_HISTORY', 'false').lower() == 'true',
 
         # 'gpt-3.5-turbo' or 'gpt-3.5-turbo-0301'
         'model': 'gpt-3.5-turbo',

--- a/openai_helper.py
+++ b/openai_helper.py
@@ -113,3 +113,9 @@ class OpenAIHelper:
         :param content: The message content
         """
         self.sessions[chat_id].append({"role": role, "content": content})
+
+        # check the history size and truncate from the top if necessary
+        max_msg_history = self.config['max_msg_history']
+        if len(self.sessions[chat_id]) > max_msg_history:
+                self.sessions[chat_id] = self.sessions[chat_id][-max_msg_history:]
+

--- a/openai_helper.py
+++ b/openai_helper.py
@@ -26,7 +26,7 @@ class OpenAIHelper:
         :return: The answer from the model
         """
         try:
-            if chat_id not in self.sessions:
+            if chat_id not in self.sessions or self.config['omit_msg_history']:
                 self.reset_chat_history(chat_id)
 
             self.__add_to_history(chat_id, role="user", content=query)


### PR DESCRIPTION
   - reduces api token usage by letting the endpoint keep track of the conversation context
   - fixes #34 