### PR TITLE
Add support for group chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ A [Telegram bot](https://core.telegram.org/bots/api) that integrates with OpenAI
 - [x] (NEW!) Automatic conversation summary to avoid excessive token usage (fixes [#34](https://github.com/n3d1117/chatgpt-telegram-bot/issues/34))
 
 ## Additional Features - help needed!
-- [ ] Group chat support
+- [x] (NEW!) Group chat support. At least one of the permitted users must be a member of the group chat. 
+
 
 PRs are always welcome!
 


### PR DESCRIPTION
per #17

- When bot is in privacy mode it must be either sent a command or replied to.  it will not receive messages when "mentioned"
- one of the authorized users must be a member of the group, in which case any group member can interact with the bot


some future improvements:
  -  when bot has privacy mode turned off it should probably reply only when mentioned
  - add a new command like /dan <prompt> - to address the bot when it's in privacy mode (might be easier than replying to an existing message from bot)