### PR TITLE
Add group chat trigger keywords

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,6 @@ MAX_CONVERSATION_AGE_MINUTES=180
 
 # Whether to answer to voice messages with the transcript or with a ChatGPT response of the transcript
 VOICE_REPLY_WITH_TRANSCRIPT_ONLY=true
+
+# Group Trigger Keyword
+GROUP_TRIGGER_KEYWORD=""

--- a/main.py
+++ b/main.py
@@ -61,6 +61,7 @@ def main():
         'allowed_user_ids': os.environ.get('ALLOWED_TELEGRAM_USER_IDS', '*'),
         'proxy': os.environ.get('PROXY', None),
         'voice_reply_transcript': os.environ.get('VOICE_REPLY_WITH_TRANSCRIPT_ONLY', 'true').lower() == 'true',
+        'group_trigger_keyword': os.environ.get('GROUP_TRIGGER_KEYWORD', ''),
     }
 
     # Setup and run ChatGPT and Telegram bot

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -184,6 +184,10 @@ class ChatGPT3TelegramBot:
         logging.info(f'New message received from user {update.message.from_user.name}')
         chat_id = update.effective_chat.id
 
+        if self.is_group_chat(update):
+            if update.message.text.find(self.config['group_trigger_keyword'], 0, len(self.config['group_trigger_keyword'])) == -1:
+                return
+
         await context.bot.send_chat_action(chat_id=chat_id, action=constants.ChatAction.TYPING)
         response = self.openai.get_chat_response(chat_id=chat_id, query=update.message.text)
         await context.bot.send_message(


### PR DESCRIPTION
After adding a bot to a group chat, prevent the bot from responding to all chats by triggering the beginning of the keyword.

`.env.example` add env:
```
# Group Trigger Keyword
GROUP_TRIGGER_KEYWORD=""
```