### PR TITLE
Adding the ability to ignore transcribing group chats

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,10 @@ MAX_HISTORY_SIZE=10
 MAX_CONVERSATION_AGE_MINUTES=180
 
 # Whether to answer to voice messages with the transcript or with a ChatGPT response of the transcript
-VOICE_REPLY_WITH_TRANSCRIPT_ONLY=true
+VOICE_REPLY_WITH_TRANSCRIPT_ONLY=false
+
+# Whether group transcriptions should be processed or not
+IGNORE_GROUP_TRANSCRIPTIONS=true
 
 # How many chat completion choices to generate for each input message
 N_CHOICES=1

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ PRESENCE_PENALTY=0 # Defaults to 0
 FREQUENCY_PENALTY=0 # Defaults to 0
 IMAGE_SIZE="256x256" # Defaults to 512x512
 GROUP_TRIGGER_KEYWORD="@bot" # Defaults to "" (no keyword required)
+IGNORE_GROUP_TRANSCRIPTIONS=true # Whether group transcriptions should be processed or not
 TOKEN_PRICE=0.002 # Defaults to 0.002, current price: https://openai.com/pricing
 IMAGE_PRICES="0.016,0.018,0.02" # Defaults to OpenAI Dall-E pricing for sizes 256x256,512x512,1024x1024
 TRANSCRIPTION_PRICE=0.006 # Defaults to minute price of OpenAI Whisper of 0.006
@@ -84,6 +85,7 @@ TRANSCRIPTION_PRICE=0.006 # Defaults to minute price of OpenAI Whisper of 0.006
 * `TEMPERATURE`: Number between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic
 * `IMAGE_SIZE`: The DALL·E generated image size. Allowed values: "256x256", "512x512", or "1024x1024"
 * `GROUP_TRIGGER_KEYWORD`: If set, the bot will only respond to messages that start with this keyword. This is useful for bots added to groups with privacy mode disabled. **Note**: by default, *no keyword* is required (`""`)
+* `IGNORE_GROUP_TRANSCRIPTIONS`: If set to false, the bot will not process transcriptions in group chats. Use this in case your group chats use a lot of audio or video messages
 * `TOKEN_PRICE`: USD-price per 1000 tokens for cost information in usage statistics. Defaults to [OpenAI price](https://openai.com/pricing) for gpt-3.5-turbo.
 * `IMAGE_PRICES`: A comma-separated list with 3 elements of prices for the different image sizes 256x256, 512x512 and 1024x1024. Defaults to [OpenAI prices](https://openai.com/pricing) for Dall-E.
 * `TRANSCRIPTION_PRICE`: USD-price for one minute of audio transcription. Defaults to [OpenAI price](https://openai.com/pricing) for Whisper.

--- a/main.py
+++ b/main.py
@@ -56,6 +56,7 @@ def main():
         'monthly_guest_budget': float(os.environ.get('MONTHLY_GUEST_BUDGET', '100.0')),
         'proxy': os.environ.get('PROXY', None),
         'voice_reply_transcript': os.environ.get('VOICE_REPLY_WITH_TRANSCRIPT_ONLY', 'true').lower() == 'true',
+        'ignore_group_transcriptions': os.environ.get('IGNORE_GROUP_TRANSCRIPTIONS', 'true').lower() == 'true',
         'group_trigger_keyword': os.environ.get('GROUP_TRIGGER_KEYWORD', ''),
         'token_price': float(os.environ.get('TOKEN_PRICE', 0.002)),
         'image_prices': [float(i) for i in os.environ.get('IMAGE_PRICES',"0.016,0.018,0.02").split(",")],

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -157,6 +157,10 @@ class ChatGPT3TelegramBot:
             await self.send_budget_reached_message(update, context)
             return
 
+        if self.is_group_chat(update) and self.config['ignore_group_transcriptions']:
+            logging.info(f'Transcription coming from group chat, ignoring...')
+            return  
+
         chat_id = update.effective_chat.id
         await context.bot.send_chat_action(chat_id=chat_id, action=constants.ChatAction.TYPING)
 


### PR DESCRIPTION
problem: bot is accidentally triggered in group chats by someone posting an audio or video message.
solution: adding configuration to ignore the transcription of group chats. transcripts will continue to work in DMs.