### PR TITLE
Allow setting system content on reset

### DIFF
--- a/bot/openai_helper.py
+++ b/bot/openai_helper.py
@@ -124,11 +124,13 @@ class OpenAIHelper:
             result = await openai.Audio.atranscribe("whisper-1", audio)
             return result.text
 
-    def reset_chat_history(self, chat_id):
+    def reset_chat_history(self, chat_id, content):
         """
         Resets the conversation history.
         """
-        self.conversations[chat_id] = [{"role": "system", "content": self.config['assistant_prompt']}]
+        if content == '':
+            content = self.config['assistant_prompt']
+        self.conversations[chat_id] = [{"role": "system", "content": content}]
 
     def __max_age_reached(self, chat_id) -> bool:
         """

--- a/bot/openai_helper.py
+++ b/bot/openai_helper.py
@@ -124,7 +124,7 @@ class OpenAIHelper:
             result = await openai.Audio.atranscribe("whisper-1", audio)
             return result.text
 
-    def reset_chat_history(self, chat_id, content):
+    def reset_chat_history(self, chat_id, content=''):
         """
         Resets the conversation history.
         """

--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -95,7 +95,8 @@ class ChatGPT3TelegramBot:
         logging.info(f'Resetting the conversation for user {update.message.from_user.name}...')
 
         chat_id = update.effective_chat.id
-        self.openai.reset_chat_history(chat_id=chat_id)
+        reset_content = update.message.text.replace('/reset', '').strip()
+        self.openai.reset_chat_history(chat_id=chat_id, content=reset_content)
         await context.bot.send_message(chat_id=chat_id, text='Done!')
 
     async def image(self, update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -26,7 +26,7 @@ class ChatGPT3TelegramBot:
         self.openai = openai
         self.commands = [
             BotCommand(command='help', description='Show help message'),
-            BotCommand(command='reset', description='Reset the conversation'),
+            BotCommand(command='reset', description='Reset the conversation. Optionally pass high-level instructions for the conversation (e.g. /reset You are a helpful assistant)'),
             BotCommand(command='image', description='Generate image from prompt (e.g. /image cat)'),
             BotCommand(command='stats', description='Get your current usage statistics')
         ]


### PR DESCRIPTION
Adding a new argument to `reset_chat_history`, allowing to pass content to it. Content still defaults to the `ASSISTANT_PROMPT` environment variable when not set.

![image](https://user-images.githubusercontent.com/7482521/226207637-66a7d095-ca29-4475-90a4-c5f95762cf97.png)

