### PR TITLE
Fix group usage permission

### DIFF
--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -1,6 +1,6 @@
 import logging
 import os
-
+import itertools
 import asyncio
 
 import telegram
@@ -628,7 +628,8 @@ class ChatGPTTelegramBot:
 
         # Check if it's a group a chat with at least one authorized member
         if self.is_group_chat(update):
-            for user in allowed_user_ids:
+            admin_user_ids = self.config['admin_user_ids'].split(',')
+            for user in itertools.chain(allowed_user_ids, admin_user_ids):
                 if await self.is_user_in_group(update, user):
                     logging.info(f'{user} is a member. Allowing group chat message...')
                     return True
@@ -712,7 +713,8 @@ class ChatGPTTelegramBot:
 
         # Check if group member is within budget
         if self.is_group_chat(update):
-            for user in allowed_user_ids:
+            admin_user_ids = self.config['admin_user_ids'].split(',')
+            for user in itertools.chain(allowed_user_ids, admin_user_ids):
                 if await self.is_user_in_group(update, user):
                     if 'guests' not in self.usage:
                         self.usage['guests'] = UsageTracker('guests', 'all guest users in group chats')


### PR DESCRIPTION
So, originally I just wanted to add the admin list to the loop that checks if an allowed user is in the group (first commit). 
But then discovered a bug in `is_user_in_group`, it only checks the first user of the allowed user list (in all my previous testing, I never put myself in a different position until I tested the addition of the admin list 🙈)
The current implementation of `is_user_in_group` raises an error if the first allowed user is not in the group and doesn't continue with the other users.
My fix is using the context (now that I think about it, maybe it would work with the previous implementation as well, if the error would be caught), so I added it to `is_allowed` and `is_within_budget`.
I gotta say, I am a bit out of my depth with the best practices of the telegram library. But for my tests it all seems to be at least functional now.