### PR TITLE
Allowing user to choose presets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__
 /usage_logs
 venv
 config.json
+.github
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 .DS_Store
 /usage_logs
 venv
+config.json

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,11 +1,16 @@
 import logging
 import os
+import json
 
 from dotenv import load_dotenv
 
 from openai_helper import OpenAIHelper, default_max_tokens
 from telegram_bot import ChatGPTTelegramBot
 
+def load_config(file_path):
+    with open(file_path, 'r') as f:
+        config = json.load(f)
+    return config
 
 def main():
     # Read .env file
@@ -14,7 +19,7 @@ def main():
     # Setup logging
     logging.basicConfig(
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        level=logging.INFO
+        level=logging.DEBUG
     )
 
     # Check if the required environment variables are set
@@ -42,6 +47,7 @@ def main():
         'model': model,
         'presence_penalty': float(os.environ.get('PRESENCE_PENALTY', 0.0)),
         'frequency_penalty': float(os.environ.get('FREQUENCY_PENALTY', 0.0)),
+        "presets": load_config('./config.json')["presets"]
     }
 
     telegram_config = {
@@ -61,7 +67,9 @@ def main():
         'token_price': float(os.environ.get('TOKEN_PRICE', 0.002)),
         'image_prices': [float(i) for i in os.environ.get('IMAGE_PRICES',"0.016,0.018,0.02").split(",")],
         'transcription_price': float(os.environ.get('TOKEN_PRICE', 0.002)),
+        "presets": load_config('./config.json')["presets"]
     }
+
 
     # Setup and run ChatGPT and Telegram bot
     openai_helper = OpenAIHelper(config=openai_config)

--- a/bot/main.py
+++ b/bot/main.py
@@ -19,7 +19,7 @@ def main():
     # Setup logging
     logging.basicConfig(
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        level=logging.DEBUG
+        level=logging.INFO
     )
 
     # Check if the required environment variables are set

--- a/bot/openai_helper.py
+++ b/bot/openai_helper.py
@@ -39,6 +39,7 @@ class OpenAIHelper:
         openai.api_key = config['api_key']
         openai.proxy = config['proxy']
         self.config = config
+        self.default_config = config
         self.conversations: dict[int: list] = {}  # {chat_id: history}
         self.last_updated: dict[int: datetime] = {}  # {chat_id: last_update_timestamp}
 
@@ -200,6 +201,17 @@ class OpenAIHelper:
         if content == '':
             content = self.config['assistant_prompt']
         self.conversations[chat_id] = [{"role": "system", "content": content}]
+
+    def change_mode(self, chat_id, mode_name=''):
+        """
+        Changes the mode of the chat.
+        """
+        presets = self.config['presets']
+        new_config = next((item for item in presets if item["title"] == mode_name), None)['openai_config']
+        self.config = self.default_config
+        self.config = {key: new_config[key] if key in new_config else self.config[key] for key in self.config}
+        self.reset_chat_history(chat_id=chat_id)
+        logging.debug(f'New mode: {self.config}')
 
     def __max_age_reached(self, chat_id) -> bool:
         """

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,24 @@
+{
+    "presets": [
+        {
+            "title": "code",
+            "openai_config": {
+                "assistant_prompt": "I want you to act as my code assistant. I'll send you some code. You need to tell me about it in plain English. If there is any bug, fix it."
+            }
+        },
+        {
+            "title": "truth",
+            "openai_config": {
+                "assistant_prompt": "You don't have to tell me the truth. But I want you to tell me the truth. I'll ask you some questions. You need to answer them honestly.",
+                "temperature": 0.1
+            }
+        },
+        {
+            "title": "cat",
+            "openai_config": {
+                "assistant_prompt": "you are a cat now. When I ask you who you are. You should answer I’m a cat",
+                "temperature": 1
+            }
+        }
+    ]
+}


### PR DESCRIPTION

## Changes

- Added functionality for users to set presets.
- Introduced a new file called config.json where users can define their preferred presets.
- Implemented the command `/mode [mode_name]` to allow users to switch between presets.
- The default preset can be set in the .env file.
- When changing to a new preset, the user's custom settings will override the default preset settings.
- When switching from one preset to another, the settings will be reset to the default preset before applying the new one.

These changes will allow users to easily switch between different preset configurations.

Thank you!