### PR TITLE
Fix token counting if stream=false

### DIFF
--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -455,7 +455,9 @@ class ChatGPTTelegramBot:
                         total_tokens = int(tokens)
 
             else:
+                total_tokens = 0
                 async def _reply():
+                    nonlocal total_tokens
                     response, total_tokens = await self.openai.get_chat_response(chat_id=chat_id, query=prompt)
 
                     # Split into chunks of 4096 characters (Telegram's message limit)

--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -490,7 +490,8 @@ class ChatGPTTelegramBot:
                 allowed_user_ids = self.config['allowed_user_ids'].split(',')
                 if str(user_id) not in allowed_user_ids and 'guests' in self.usage:
                     self.usage["guests"].add_chat_tokens(total_tokens, self.config['token_price'])
-            except:
+            except Exception as e:
+                logging.warning(f'Failed to add tokens to usage_logs: {str(e)}')
                 pass
 
         except Exception as e:


### PR DESCRIPTION
fixes #211 #212 

total_tokens was not used within the `__reply()` function and not accessible in line 486 to be added to the users token count, throwing the undefined exception in line 491.
changed the scope of total_tokens as `nonlocal`