### PR TITLE
Add support for quoting replied messages

### DIFF
--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -401,6 +401,14 @@ class ChatGPTTelegramBot:
             trigger_keyword = self.config['group_trigger_keyword']
             if prompt.lower().startswith(trigger_keyword.lower()):
                 prompt = prompt[len(trigger_keyword):].strip()
+
+                if update.message.reply_to_message and \
+                        update.message.reply_to_message.text and \
+                        update.message.reply_to_message.from_user.id != context.bot.id:
+                    prompt = '"{reply}" {prompt}'.format(
+                        reply=update.message.reply_to_message.text,
+                        prompt=prompt
+                    )
             else:
                 if update.message.reply_to_message and update.message.reply_to_message.from_user.id == context.bot.id:
                     logging.info('Message is a reply to the bot, allowing...')


### PR DESCRIPTION
This allows users to quote a message when replying to it in a group chat, making the conversation context clearer.
It makes no sense to add to personal chats, since the bot will already have context, so only for groups. If I'm wrong correct me 

Issue #156 

<img width="512" alt="image" src="https://user-images.githubusercontent.com/86171768/236453887-90aba1c6-3777-4c96-ae40-a08b425680af.png">
