### PR TITLE
Auto retry while rate limited using tenacity

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -16,6 +16,7 @@ def main():
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
         level=logging.INFO
     )
+    logging.getLogger("httpx").setLevel(logging.WARNING)
 
     # Check if the required environment variables are set
     required_values = ['TELEGRAM_BOT_TOKEN', 'OPENAI_API_KEY']

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,6 @@ python-dotenv~=1.0.0
 pydub~=0.25.1
 tiktoken==0.4.0
 openai==0.27.8
-python-telegram-bot==20.2
+python-telegram-bot==20.3
+requests~=2.31.0
+tenacity==8.2.2


### PR DESCRIPTION
Automatically retry openai chat completion calls after 20s while being rate limited. Should reduce errors of type:

```
error_code=None error_message='Rate limit reached for default-gpt-3.5-turbo in organization org-xxx on requests per min. Limit: 3 / min. Please try again in 20s. Contact us through our help center at help.openai.com if you continue to have issues. Please add a payment method to your account to increase your rate limit. Visit https://platform.openai.com/account/billing to add a payment method.' error_param=None error_type=requests message='OpenAI API error received' stream_error=False
```