### PR TITLE
(fix) Passing context

### DIFF
--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -370,7 +370,14 @@ class ChatGPTTelegramBot:
 
         if is_group_chat(update):
             trigger_keyword = self.config['group_trigger_keyword']
-            if prompt.lower().startswith(trigger_keyword.lower()):
+
+            raw_text = update.message.text.lower()
+            prompt_lower = prompt.lower()
+
+            if raw_text.startswith('/chat') or prompt_lower.startswith(trigger_keyword):
+                if not prompt_lower.startswith(trigger_keyword):
+                    prompt = f'{trigger_keyword} {prompt}'
+
                 prompt = prompt[len(trigger_keyword):].strip()
 
                 if update.message.reply_to_message and \

--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -371,14 +371,9 @@ class ChatGPTTelegramBot:
         if is_group_chat(update):
             trigger_keyword = self.config['group_trigger_keyword']
 
-            raw_text = update.message.text.lower()
-            prompt_lower = prompt.lower()
-
-            if raw_text.startswith('/chat') or prompt_lower.startswith(trigger_keyword):
-                if not prompt_lower.startswith(trigger_keyword):
-                    prompt = f'{trigger_keyword} {prompt}'
-
-                prompt = prompt[len(trigger_keyword):].strip()
+            if prompt.lower().startswith(trigger_keyword.lower()) or update.message.text.lower().startswith('/chat'):
+                if prompt.lower().startswith(trigger_keyword.lower()):
+                    prompt = prompt[len(trigger_keyword):].strip()
 
                 if update.message.reply_to_message and \
                         update.message.reply_to_message.text and \


### PR DESCRIPTION
Issue #348 

Added the feature for the bot to see the context when used:
 - /chat
 - /chat "GROUP_TRIGGER_KEYWORD"

<img width="350" alt="image" src="https://github.com/n3d1117/chatgpt-telegram-bot/assets/86171768/64c5607c-c872-45e6-9e79-124241df7eaa">
