### PR TITLE
fix: screenshot not showing properly if the website is slow

### DIFF
--- a/bot/plugins/webshot.py
+++ b/bot/plugins/webshot.py
@@ -54,4 +54,7 @@ class WebshotPlugin(Plugin):
             else:
                 return {'result': 'Unable to screenshot website'}
         except:
+            if 'image_file_path' in locals():
+                os.remove(image_file_path)
+                
             return {'result': 'Unable to screenshot website'}

--- a/bot/plugins/webshot.py
+++ b/bot/plugins/webshot.py
@@ -1,3 +1,4 @@
+import os, requests, random, string
 from typing import Dict
 from .plugin import Plugin
 
@@ -11,21 +12,41 @@ class WebshotPlugin(Plugin):
     def get_spec(self) -> [Dict]:
         return [{
             "name": "screenshot_website",
-            "description": "Show screenshot/image of a website from a given url or domain name",
+            "description": "Show screenshot/image of a website from a given url or domain name.",
             "parameters": {
                 "type": "object",
                 "properties": {
-                    "url": {"type": "string", "description": "Website url or domain name"}
+                    "url": {"type": "string", "description": "Website url or domain name. Correctly formatted url is required. Example: https://www.google.com"}
                 },
                 "required": ["url"],
             },
         }]
+    
+    def generate_random_string(self, length):
+        characters = string.ascii_letters + string.digits
+        return ''.join(random.choice(characters) for _ in range(length))
 
     async def execute(self, function_name, **kwargs) -> Dict:
-        return {
-            'direct_result': {
-                'kind': 'photo',
-                'format': 'url',
-                'value': f'https://image.thum.io/get/maxAge/12/width/720/{kwargs["url"]}'
-            }
-        }
+        try:
+            image_url = f'https://image.thum.io/get/maxAge/12/width/720/{kwargs["url"]}'
+            response = requests.get(image_url, timeout=30)
+
+            if response.status_code == 200:
+                if not os.path.exists("uploads/webshot"):
+                    os.makedirs("uploads/webshot")
+
+                image_file_path = os.path.join("uploads/webshot", f"{self.generate_random_string(15)}.png")
+                with open(image_file_path, "wb") as f:
+                    f.write(response.content)
+
+                return {
+                    'direct_result': {
+                        'kind': 'photo',
+                        'format': 'path',
+                        'value': image_file_path
+                    }
+                }
+            else:
+                return {'result': 'Unable to screenshot website'}
+        except:
+            return {'result': 'Unable to screenshot website'}

--- a/bot/plugins/webshot.py
+++ b/bot/plugins/webshot.py
@@ -29,6 +29,11 @@ class WebshotPlugin(Plugin):
     async def execute(self, function_name, **kwargs) -> Dict:
         try:
             image_url = f'https://image.thum.io/get/maxAge/12/width/720/{kwargs["url"]}'
+            
+            # preload url first
+            requests.get(image_url)
+
+            # download the actual image
             response = requests.get(image_url, timeout=30)
 
             if response.status_code == 200:


### PR DESCRIPTION
i had to make some changes in the webshot plugin because it shows the **thum** loading image instead of the actual website image if the target url has a slow response time. it will now download the image, waiting for full load, and then pass it as a file path.

![image](https://github.com/n3d1117/chatgpt-telegram-bot/assets/46517631/e3d7537d-c57e-4bbb-8290-66acccaa9c60)

i tested and it seems **effective_message.reply_photo** automatically deletes the file after sending to user which i think is good.