### PR TITLE
Add "prompting" to whisper

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Check out the [Budget Manual](https://github.com/n3d1117/chatgpt-telegram-bot/di
 | `GROUP_TRIGGER_KEYWORD`            | If set, the bot in group chats will only respond to messages that start with this keyword                                                                                                                                                                             | -                                   |
 | `IGNORE_GROUP_TRANSCRIPTIONS`      | If set to true, the bot will not process transcriptions in group chats                                                                                                                                                                                                | `true`                              |
 | `BOT_LANGUAGE`                     | Language of general bot messages. Currently available: `en`, `de`, `ru`, `tr`, `it`, `fi`, `es`, `id`, `nl`, `zh-cn`, `zh-tw`, `vi`, `fa`, `pt-br`, `uk`.  [Contribute with additional translations](https://github.com/n3d1117/chatgpt-telegram-bot/discussions/219) | `en`                                |
+| `WHISPER_PROMPT`                     | To improve the accuracy of Whisper's transcription service, especially for specific names or terms, you can set up a custom message.  [Speech to text - Prompting](https://platform.openai.com/docs/guides/speech-to-text/prompting) | `-`                                |
 
 Check out the [official API reference](https://platform.openai.com/docs/api-reference/chat) for more details.
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -49,6 +49,7 @@ def main():
         'frequency_penalty': float(os.environ.get('FREQUENCY_PENALTY', 0.0)),
         'bot_language': os.environ.get('BOT_LANGUAGE', 'en'),
         'show_plugins_used': os.environ.get('SHOW_PLUGINS_USED', 'false').lower() == 'true',
+        'whisper_prompt': os.environ.get('WHISPER_PROMPT', ''),
     }
 
     if openai_config['enable_functions'] and not functions_available:

--- a/bot/openai_helper.py
+++ b/bot/openai_helper.py
@@ -341,7 +341,8 @@ class OpenAIHelper:
         """
         try:
             with open(filename, "rb") as audio:
-                result = await openai.Audio.atranscribe("whisper-1", audio)
+                prompt_text = os.environ.get('WHISPER_PROMPT', '')
+                result = await openai.Audio.atranscribe("whisper-1", audio, prompt=prompt_text)
                 return result.text
         except Exception as e:
             logging.exception(e)

--- a/bot/openai_helper.py
+++ b/bot/openai_helper.py
@@ -341,7 +341,7 @@ class OpenAIHelper:
         """
         try:
             with open(filename, "rb") as audio:
-                prompt_text = os.environ.get('WHISPER_PROMPT', '')
+                prompt_text = self.config['whisper_prompt']
                 result = await openai.Audio.atranscribe("whisper-1", audio, prompt=prompt_text)
                 return result.text
         except Exception as e:


### PR DESCRIPTION
The possibility of passing indications to whisper is added, by default none are sent, like the default model.

Prompts can help Whisper write unfamiliar words or acronyms.

https://platform.openai.com/docs/guides/speech-to-text/prompting