### PR TITLE
Update Dockerfile so it works in Raspberry py and arm systems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,23 @@
-FROM python:3.9-alpine
+FROM python:3.9-slim-buster
 
 ENV PYTHONFAULTHANDLER=1 \
      PYTHONUNBUFFERED=1 \
      PYTHONDONTWRITEBYTECODE=1 \
      PIP_DISABLE_PIP_VERSION_CHECK=on
 
-RUN apk --no-cache add ffmpeg
+RUN apt-get update && apt-get install -y \
+    libxml2-dev \
+    libxslt-dev \
+    curl \
+    build-essential \
+    ffmpeg \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 WORKDIR /app
 COPY . .
 RUN pip install -r requirements.txt --no-cache-dir
-
-CMD ["python", "bot/main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,5 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 WORKDIR /app
 COPY . .
 RUN pip install -r requirements.txt --no-cache-dir
+
+CMD ["python", "bot/main.py"]


### PR DESCRIPTION
The Dockerfile as it stands now will throw a few build errors due to the lack of pre-built files in general for the raspberry pi architecture. The proposed dockerfile works in the Raspberry pi and should work anywhere else, although it takes a bit longer to load. This is just a proposal but it could be done in a separate Dockerfile instead. Tested and working.

Ps: Thanks for this amazing work :)