### PR TITLE
deepl plugin fix: avoid unicode escape characters in the response containing non-ANSI characters

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,4 @@
 .github
 .gitignore
 docker-compose.yml
-Dockerfilegit 
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.env
+.dockerignore
+.github
+.gitignore
+docker-compose.yml
+Dockerfilegit 

--- a/bot/plugins/deepl.py
+++ b/bot/plugins/deepl.py
@@ -49,4 +49,5 @@ class DeeplTranslatePlugin(Plugin):
             "text": kwargs['text'],
             "target_lang": kwargs['to_language']
         }
-        return requests.post(url, headers=headers, data=data).json()["translations"][0]["text"]
+        translated_text = requests.post(url, headers=headers, data=data).json()["translations"][0]["text"]
+        return translated_text.encode('unicode-escape').decode('unicode-escape')

--- a/bot/plugins/deepl.py
+++ b/bot/plugins/deepl.py
@@ -42,7 +42,8 @@ class DeeplTranslatePlugin(Plugin):
         headers = {
             "Authorization": f"DeepL-Auth-Key {self.api_key}",
             "User-Agent": "chatgpt-telegram-bot",
-            "Content-Type": "application/x-www-form-urlencoded"
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept-Encoding": "utf-8"
         }
         data = {
             "text": kwargs['text'],


### PR DESCRIPTION
reason for this change is to get Unicode escape characters in the response containing non-ANSI characters

potential fix for issue #541

Fix tested on my side, works fine:

![image](https://github.com/n3d1117/chatgpt-telegram-bot/assets/22106917/cda38155-19a0-47b4-9850-7db1f7a78b0e)
