### PR TITLE
Remove Unnecessary F-strings

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -64,7 +64,7 @@ def main():
 
     if openai_config['enable_functions'] and not functions_available:
         logging.error(f'ENABLE_FUNCTIONS is set to true, but the model {model} does not support it. '
-                        f'Please set ENABLE_FUNCTIONS to false or use a model that supports it.')
+                        'Please set ENABLE_FUNCTIONS to false or use a model that supports it.')
         exit(1)
     if os.environ.get('MONTHLY_USER_BUDGETS') is not None:
         logging.warning('The environment variable MONTHLY_USER_BUDGETS is deprecated. '

--- a/bot/plugins/weather.py
+++ b/bot/plugins/weather.py
@@ -58,7 +58,7 @@ class WeatherPlugin(Plugin):
         ]
 
     async def execute(self, function_name, helper, **kwargs) -> Dict:
-        url = f'https://api.open-meteo.com/v1/forecast' \
+        url = 'https://api.open-meteo.com/v1/forecast' \
               f'?latitude={kwargs["latitude"]}' \
               f'&longitude={kwargs["longitude"]}' \
               f'&temperature_unit={kwargs["unit"]}'

--- a/bot/plugins/worldtimeapi.py
+++ b/bot/plugins/worldtimeapi.py
@@ -21,13 +21,13 @@ class WorldTimeApiPlugin(Plugin):
     def get_spec(self) -> [Dict]:
         return [{
             "name": "worldtimeapi",
-            "description": f"Get the current time from a given timezone",
+            "description": "Get the current time from a given timezone",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "timezone": {
                         "type": "string",
-                        "description": f"The timezone identifier (e.g: `Europe/Rome`). Infer this from the location."
+                        "description": "The timezone identifier (e.g: `Europe/Rome`). Infer this from the location."
                                        f"Use {self.default_timezone} if not specified."
                     }
                 },

--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -84,12 +84,12 @@ class ChatGPTTelegramBot:
         """
         if not await is_allowed(self.config, update, context):
             logging.warning(f'User {update.message.from_user.name} (id: {update.message.from_user.id}) '
-                            f'is not allowed to request their usage statistics')
+                            'is not allowed to request their usage statistics')
             await self.send_disallowed_message(update, context)
             return
 
         logging.info(f'User {update.message.from_user.name} (id: {update.message.from_user.id}) '
-                     f'requested their usage statistics')
+                     'requested their usage statistics')
 
         user_id = update.message.from_user.id
         if user_id not in self.usage:
@@ -112,7 +112,7 @@ class ChatGPTTelegramBot:
             f"*{localized_text('stats_conversation', bot_language)[0]}*:\n"
             f"{chat_messages} {localized_text('stats_conversation', bot_language)[1]}\n"
             f"{chat_token_length} {localized_text('stats_conversation', bot_language)[2]}\n"
-            f"----------------------------\n"
+            "----------------------------\n"
         )
         
         # Check if image generation is enabled and, if so, generate the image statistics for today
@@ -137,7 +137,7 @@ class ChatGPTTelegramBot:
             f"{transcribe_minutes_today} {localized_text('stats_transcribe', bot_language)[0]} "
             f"{transcribe_seconds_today} {localized_text('stats_transcribe', bot_language)[1]}\n"
             f"{localized_text('stats_total', bot_language)}{current_cost['cost_today']:.2f}\n"
-            f"----------------------------\n"
+            "----------------------------\n"
         )
         
         text_month_images = ""
@@ -190,14 +190,14 @@ class ChatGPTTelegramBot:
         """
         if not await is_allowed(self.config, update, context):
             logging.warning(f'User {update.message.from_user.name}  (id: {update.message.from_user.id})'
-                            f' is not allowed to resend the message')
+                            ' is not allowed to resend the message')
             await self.send_disallowed_message(update, context)
             return
 
         chat_id = update.effective_chat.id
         if chat_id not in self.last_message:
             logging.warning(f'User {update.message.from_user.name} (id: {update.message.from_user.id})'
-                            f' does not have anything to resend')
+                            ' does not have anything to resend')
             await update.effective_message.reply_text(
                 message_thread_id=get_thread_id(update),
                 text=localized_text('resend_failed', self.config['bot_language'])
@@ -218,7 +218,7 @@ class ChatGPTTelegramBot:
         """
         if not await is_allowed(self.config, update, context):
             logging.warning(f'User {update.message.from_user.name} (id: {update.message.from_user.id}) '
-                            f'is not allowed to reset the conversation')
+                            'is not allowed to reset the conversation')
             await self.send_disallowed_message(update, context)
             return
 
@@ -339,7 +339,7 @@ class ChatGPTTelegramBot:
             return
 
         if is_group_chat(update) and self.config['ignore_group_transcriptions']:
-            logging.info(f'Transcription coming from group chat, ignoring...')
+            logging.info('Transcription coming from group chat, ignoring...')
             return
 
         chat_id = update.effective_chat.id
@@ -463,13 +463,13 @@ class ChatGPTTelegramBot:
 
         if is_group_chat(update):
             if self.config['ignore_group_vision']:
-                logging.info(f'Vision coming from group chat, ignoring...')
+                logging.info('Vision coming from group chat, ignoring...')
                 return
             else:
                 trigger_keyword = self.config['group_trigger_keyword']
                 if (prompt is None and trigger_keyword != '') or \
                    (prompt is not None and not prompt.lower().startswith(trigger_keyword.lower())):
-                    logging.info(f'Vision coming from group chat with wrong keyword, ignoring...')
+                    logging.info('Vision coming from group chat with wrong keyword, ignoring...')
                     return
         
         image = update.message.effective_attachment[-1]


### PR DESCRIPTION
This codemod converts any f-strings without interpolated variables into regular strings.
In these cases the use of f-string is not necessary; a simple string literal is sufficient. 

While in some (extreme) cases we might expect a very modest performance
improvement, in general this is a fix that improves the overall cleanliness and
quality of your code.

```diff
- var = f"hello"
+ var = "hello"
  ...
```

<details>
  <summary>More reading</summary>

  * [https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/f-string-without-interpolation.html](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/f-string-without-interpolation.html)
  * [https://github.com/Instagram/LibCST/blob/main/libcst/codemod/commands/unnecessary_format_string.py](https://github.com/Instagram/LibCST/blob/main/libcst/codemod/commands/unnecessary_format_string.py)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/remove-unnecessary-f-str](https://docs.pixee.ai/codemods/python/pixee_python_remove-unnecessary-f-str)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fchatgpt-telegram-bot%7Cb526d48dbdb9a6b7b473fee3c74ac2742f8abcc4)

<!--{"type":"DRIP","codemod":"pixee:python/remove-unnecessary-f-str"}-->