### PR TITLE
Fix inline mode

### DIFF
--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -843,7 +843,7 @@ class ChatGPTTelegramBot:
                 title=localized_text("ask_chatgpt", bot_language),
                 input_message_content=InputTextMessageContent(message_content),
                 description=message_content,
-                thumb_url='https://user-images.githubusercontent.com/11541888/223106202-7576ff11-2c8e-408d-94ea'
+                thumbnail_url='https://user-images.githubusercontent.com/11541888/223106202-7576ff11-2c8e-408d-94ea'
                           '-b02a7a32149a.png',
                 reply_markup=reply_markup
             )


### PR DESCRIPTION
> Changed in version 20.5: Removed the deprecated arguments and attributes thumb_*

https://docs.python-telegram-bot.org/en/stable/telegram.inlinequeryresultarticle.html#telegram.InlineQueryResultArticle.params.thumbnail_url