### PR TITLE
fix: dice.py

### DIFF
--- a/bot/plugins/dice.py
+++ b/bot/plugins/dice.py
@@ -28,7 +28,7 @@ class DicePlugin(Plugin):
             },
         }]
 
-    async def execute(self, function_name, **kwargs) -> Dict:
+    async def execute(self, function_name, helper, **kwargs) -> Dict:
         return {
             'direct_result': {
                 'kind': 'dice',


### PR DESCRIPTION
Adding `helper` as an additional argument to solve the following issue in `dice.py`: 

```bash
Traceback (most recent call last):
  File "/Users/damian/software/chatgpt-telegram-bot/bot/telegram_bot.py", line 697, in prompt
    async for content, tokens in stream_response:
  File "/Users/damian/software/chatgpt-telegram-bot/bot/openai_helper.py", line 184, in get_chat_response_stream
    response, plugins_used = await self.__handle_function_call(chat_id, response, stream=True)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/damian/software/chatgpt-telegram-bot/bot/openai_helper.py", line 310, in __handle_function_call
    function_response = await self.plugin_manager.call_function(function_name, self, arguments)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/damian/software/chatgpt-telegram-bot/bot/plugin_manager.py", line 61, in call_function
    return json.dumps(await plugin.execute(function_name, helper, **json.loads(arguments)), default=str)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: DicePlugin.execute() takes 2 positional arguments but 3 were given
```